### PR TITLE
Change Restaurant ID handling and fix surviving mutation in AmusementParks

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RestaurantsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RestaurantsController.java
@@ -54,7 +54,6 @@ public class RestaurantsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public Restaurant postRestaurants(
-        @ApiParam("id") @RequestParam Long id,
         @ApiParam("name") @RequestParam String name,
         @ApiParam("address") @RequestParam String address,
         @ApiParam("specialty") @RequestParam String specialty
@@ -62,7 +61,6 @@ public class RestaurantsController extends ApiController {
         {
 
         Restaurant restaurants = new Restaurant();
-        restaurants.setId(id);
         restaurants.setName(name);
         restaurants.setAddress(address);
         restaurants.setSpecialty(specialty);
@@ -76,7 +74,7 @@ public class RestaurantsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("")
     public Object deleteRestaurants(
-            @ApiParam("code") @RequestParam Long id) {
+            @ApiParam("id") @RequestParam Long id) {
         Restaurant restaurants = restaurantsRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Restaurant.class, id));
 
@@ -88,14 +86,13 @@ public class RestaurantsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("")
     public Restaurant updateRestaurants(
-            @ApiParam("code") @RequestParam Long id,
+            @ApiParam("id") @RequestParam Long id,
             @RequestBody @Valid Restaurant incoming) {
 
         Restaurant restaurants = restaurantsRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Restaurant.class, id));
 
 
-        restaurants.setId(incoming.getId());
         restaurants.setName(incoming.getName());
         restaurants.setAddress(incoming.getAddress());
         restaurants.setSpecialty(incoming.getSpecialty());

--- a/src/test/java/edu/ucsb/cs156/example/controllers/AmusementParksControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/AmusementParksControllerTests.java
@@ -246,7 +246,7 @@ public class AmusementParksControllerTests extends ControllerTestCase{
                 AmusementPark UniversalStudioEdited = AmusementPark.builder()
                                 .name("UniversalStudio")
                                 .address("100 Universal City Plaza, Universal City, CA 91608")
-                                .description("A Universal Studio theme park built for Universal Studio film fans")
+                                .description("Universal theme park built for Universal film fans")
                                 .build();
 
                 String requestBody = mapper.writeValueAsString(UniversalStudioEdited);

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RestaurantsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RestaurantsControllerTests.java
@@ -4,7 +4,6 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.Restaurant;
-import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
 import edu.ucsb.cs156.example.repositories.RestaurantsRepository;
 
 import java.util.ArrayList;
@@ -87,7 +86,6 @@ public class RestaurantsControllerTests extends ControllerTestCase {
                 // arrange
 
                 Restaurant restaurant = Restaurant.builder()
-                                .id(1l)
                                 .name("KazuNori: The Original Hand Roll Bar")
                                 .address("1110 Gayley Ave, Los Angeles, CA 90024")
                                 .specialty("Sushi - Hand Rolls")
@@ -134,14 +132,12 @@ public class RestaurantsControllerTests extends ControllerTestCase {
                 // arrange
 
                 Restaurant kazunori = Restaurant.builder()
-                                .id(1l)
                                 .name("KazuNori: The Original Hand Roll Bar")
                                 .address("1110 Gayley Ave, Los Angeles, CA 90024")
                                 .specialty("Sushi - Hand Rolls")
                                 .build();
 
                 Restaurant sun = Restaurant.builder()
-                                .id(2l)
                                 .name("Sun Sushi")
                                 .address("3631 State St, Santa Barbara, CA 93105")
                                 .specialty("Sushi")
@@ -170,7 +166,6 @@ public class RestaurantsControllerTests extends ControllerTestCase {
                 // arrange
 
                 Restaurant sun = Restaurant.builder()
-                                .id(2l)
                                 .name("Sun Sushi")
                                 .address("3631 State St, Santa Barbara, CA 93105")
                                 .specialty("Sushi")
@@ -180,7 +175,7 @@ public class RestaurantsControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/restaurants/post?id=2&name=Sun Sushi&address=3631 State St, Santa Barbara, CA 93105&specialty=Sushi")
+                                post("/api/restaurants/post?name=Sun Sushi&address=3631 State St, Santa Barbara, CA 93105&specialty=Sushi")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -197,7 +192,6 @@ public class RestaurantsControllerTests extends ControllerTestCase {
                 // arrange
 
                 Restaurant kazunori = Restaurant.builder()
-                                .id(1l)
                                 .name("KazuNori: The Original Hand Roll Bar")
                                 .address("1110 Gayley Ave, Los Angeles, CA 90024")
                                 .specialty("Sushi - Hand Rolls")
@@ -245,14 +239,12 @@ public class RestaurantsControllerTests extends ControllerTestCase {
                 // arrange
 
                 Restaurant kazunoriOrig = Restaurant.builder()
-                                .id(1l)
                                 .name("KazuNori: The Original Hand Roll Bar")
                                 .address("1110 Gayley Ave, Goleta, CA 90024")
                                 .specialty("Burgers")
                                 .build();
 
                 Restaurant kazunoriEdited = Restaurant.builder()
-                                .id(2l)
                                 .name("KazuNori")
                                 .address("1110 Gayley Ave, Los Angeles, CA 90024")
                                 .specialty("Sushi - Hand Rolls")
@@ -284,7 +276,6 @@ public class RestaurantsControllerTests extends ControllerTestCase {
                 // arrange
 
                 Restaurant kazunoriEdited = Restaurant.builder()
-                                .id(2l)
                                 .name("KazuNori")
                                 .address("1110 Gayley Ave, Los Angeles, CA 90024")
                                 .specialty("Sushi - Hand Rolls")


### PR DESCRIPTION
In this PR, I've changed the Restaurant controller in how it handles the "id" field:
- I've removed the setter lines for "id," since the `Restaurant` Entity uses a generated ID and not a unique code.
- I've also changed some surviving instances of the word "code" to "id" to match the example given by UCSBDate. Not 100% sure if that makes a difference, but might as well.

While testing, I also found that there was a surviving mutation in the test for the AmusementPark controller: This was caused by the test for PUT not actually changing the description between the original and the edited versions of the AmusementPark used in the test. I've changed it to kill the mutation.

There is also one more minor change made by deleting an unnecessary import from UCSBDiningCommons.